### PR TITLE
Add parseUrls to message definition

### DIFF
--- a/src/accessors/IModify.ts
+++ b/src/accessors/IModify.ts
@@ -283,6 +283,18 @@ export interface IMessageBuilder {
     getUsernameAlias(): string;
 
     /**
+     * Set whether urls should be parsed or not.
+     *
+     * @param alias the username alias to display
+     */
+    setParseUrls(parseUrls: boolean): IMessageBuilder;
+
+    /**
+     * Gets whether urls should be parsed or not.
+     */
+    getParseUrls(): boolean;
+
+    /**
      * Adds one attachment to the message's list of attachments, this will not
      * overwrite any existing ones but just adds.
      *

--- a/src/accessors/IModify.ts
+++ b/src/accessors/IModify.ts
@@ -285,7 +285,7 @@ export interface IMessageBuilder {
     /**
      * Set whether urls should be parsed or not.
      *
-     * @param alias the username alias to display
+     * @param parseUrls value determines whether urls should be parsed or not  
      */
     setParseUrls(parseUrls: boolean): IMessageBuilder;
 

--- a/src/messages/IMessage.ts
+++ b/src/messages/IMessage.ts
@@ -14,6 +14,7 @@ export interface IMessage {
     emoji?: string;
     avatarUrl?: string;
     alias?: string;
+    parseUrls?: boolean;
     attachments?: Array<IMessageAttachment>;
     customFields?: { [key: string]: any };
 }

--- a/src/messages/IMessage.ts
+++ b/src/messages/IMessage.ts
@@ -14,7 +14,7 @@ export interface IMessage {
     emoji?: string;
     avatarUrl?: string;
     alias?: string;
-    parseUrls?: boolean;
     attachments?: Array<IMessageAttachment>;
     customFields?: { [key: string]: any };
+    parseUrls?: boolean;
 }


### PR DESCRIPTION
parseUrls was over looked during the definition of the message object, as @graywolf336 mentioned in a forums post.

https://forums.rocket.chat/t/will-it-be-possible-to-toggle-link-preview-with-rocket-chat-apps/1756/3

I hope I didn't miss something :)